### PR TITLE
Add mount as a private member var

### DIFF
--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -3,6 +3,8 @@ import * as THREE from 'three';
 
 class Renderer extends Component {
 
+  private mount: HTMLDivElement | null = null;
+
 	componentDidMount() {
 
 		var scene = new THREE.Scene();
@@ -11,7 +13,9 @@ class Renderer extends Component {
     renderer.setSize( window.innerWidth, window.innerHeight );
     // document.body.appendChild( renderer.domElement );
     // use ref as a mount point of the Three.js scene instead of the document.body
-    this.mount.appendChild( renderer.domElement );
+    if (this.mount) {
+      this.mount.appendChild( renderer.domElement );
+    }
     var geometry = new THREE.BoxGeometry( 1, 1, 1 );
     var material = new THREE.MeshBasicMaterial( { color: 0x00ff00 } );
     var cube = new THREE.Mesh( geometry, material );


### PR DESCRIPTION
Here's how you fix that issue!  

Since mount isn't predefined on `Renderer` typescript complains about it.  It's kind of like C#/Unity in that way.